### PR TITLE
Fixes for the issues #2 + #3

### DIFF
--- a/src/OpenGraphParser/OpenGraphParser.php
+++ b/src/OpenGraphParser/OpenGraphParser.php
@@ -54,12 +54,22 @@ class OpenGraphParser {
         return $out;
     }
 
-    public function setFetchStrategy(\OpenGraphParser\AbstractFetchStrategy $strategy) {
+    public function setFetchStrategy(AbstractFetchStrategy $strategy) {
+        if(!is_null($this->cacheAdapter)) {
+            $strategy->setCacheAdapter($this->cacheAdapter);
+        }
+
         $this->fetchStrategy = $strategy;
     }
 
     public function getFetchStrategy() {
         return $this->fetchStrategy;
+    }
+    
+    public function setCacheAdapter($cacheAdapter) {
+        $this->fetchStrategy->setCacheAdapter($cacheAdapter);
+
+        $this->cacheAdapter = $cacheAdapter;
     }
 
     public function getCacheAdapter() {

--- a/tests/OpenGraphParser/OpenGraphParserTest.php
+++ b/tests/OpenGraphParser/OpenGraphParserTest.php
@@ -321,6 +321,22 @@ class OpenGraphParserTest extends \PHPUnit_Framework_TestCase
         $results = $this->subject->parseList(array('first','second','third'));
         $this->assertEquals(2, count($results));
     }
+    
+    public function testSettingNewCacheAdapterItAlsoShouldSetItOnTheFetchStrategy()
+    {
+        $this->subject->setCacheAdapter(new ArrayCacheAdapter);
+
+        $this->assertInstanceOf('OpenGraphParser\ArrayCacheAdapter', $this->subject->getCacheAdapter());
+        $this->assertInstanceOf('OpenGraphParser\ArrayCacheAdapter', $this->subject->getFetchStrategy()->getCacheAdapter());
+    }
+
+    public function testSettingNewFetchStrategyTheCacheAdapterShouldBeAssignedToIt()
+    {
+        $this->subject->setCacheAdapter(new ArrayCacheAdapter);
+        $this->subject->setFetchStrategy(new FileFetchStrategy);
+
+        $this->assertInstanceOf('OpenGraphParser\ArrayCacheAdapter', $this->subject->getFetchStrategy()->getCacheAdapter());
+    }
 
 }
 

--- a/tests/OpenGraphParser/OpenGraphParserTest.php
+++ b/tests/OpenGraphParser/OpenGraphParserTest.php
@@ -328,6 +328,11 @@ class OpenGraphParserTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('OpenGraphParser\ArrayCacheAdapter', $this->subject->getCacheAdapter());
         $this->assertInstanceOf('OpenGraphParser\ArrayCacheAdapter', $this->subject->getFetchStrategy()->getCacheAdapter());
+        
+        $this->subject->setCacheAdapter(new NoCacheAdapter);
+
+        $this->assertInstanceOf('OpenGraphParser\NoCacheAdapter', $this->subject->getCacheAdapter());
+        $this->assertInstanceOf('OpenGraphParser\NoCacheAdapter', $this->subject->getFetchStrategy()->getCacheAdapter());
     }
 
     public function testSettingNewFetchStrategyTheCacheAdapterShouldBeAssignedToIt()
@@ -336,6 +341,11 @@ class OpenGraphParserTest extends \PHPUnit_Framework_TestCase
         $this->subject->setFetchStrategy(new FileFetchStrategy);
 
         $this->assertInstanceOf('OpenGraphParser\ArrayCacheAdapter', $this->subject->getFetchStrategy()->getCacheAdapter());
+        
+        $this->subject->setCacheAdapter(new NoCacheAdapter);
+        $this->subject->setFetchStrategy(new FileFetchStrategy);
+
+        $this->assertInstanceOf('OpenGraphParser\NoCacheAdapter', $this->subject->getFetchStrategy()->getCacheAdapter());
     }
 
 }


### PR DESCRIPTION
When setting a new CacheAdapter, also set it on the FetchStrategy.
When setting a new FetchStrategy, set the existing CacheAdapter to the FetchStrategy.

There is also unit testing for this.
